### PR TITLE
Kafka client 4.0

### DIFF
--- a/application/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/application/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -16,12 +16,13 @@
  */
 
 /*
- * Content of this file was modified to addresses the issue https://issues.apache.org/jira/browse/KAFKA-4090
+ * Content of this file was modified to address the issue https://issues.apache.org/jira/browse/KAFKA-4090
  *
  */
 package org.apache.kafka.common.network;
 
 import org.apache.kafka.common.memory.MemoryPool;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.thingsboard.server.common.data.exception.ThingsboardKafkaClientError;
@@ -103,13 +104,13 @@ public class NetworkReceive implements Receive {
                 if (maxSize != UNLIMITED && receiveSize > maxSize) {
                     throw new ThingsboardKafkaClientError("Invalid receive (size = " + receiveSize + " larger than " + maxSize + ")");
                 }
-                requestedBufferSize = receiveSize; //may be 0 for some payloads (SASL)
+                requestedBufferSize = receiveSize; // may be 0 for some payloads (SASL)
                 if (receiveSize == 0) {
                     buffer = EMPTY_BUFFER;
                 }
             }
         }
-        if (buffer == null && requestedBufferSize != -1) { //we know the size we want but havent been able to allocate it yet
+        if (buffer == null && requestedBufferSize != -1) { // we know the size we want but haven't been able to allocate it yet
             if (requestedBufferSize > TB_LOG_REQUESTED_BUFFER_SIZE) {
                 String stackTrace = Arrays.stream(Thread.currentThread().getStackTrace()).map(StackTraceElement::toString).collect(Collectors.joining("|"));
                 log.error("Allocating buffer of size {} for source {}", requestedBufferSize, source);

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <!-- IMPORTANT: If you change the version of the kafka client, make sure to synchronize our overwritten implementation of the
         org.apache.kafka.common.network.NetworkReceive class in the application module. It addresses the issue https://issues.apache.org/jira/browse/KAFKA-4090.
         Here is the source to track https://github.com/apache/kafka/tree/trunk/clients/src/main/java/org/apache/kafka/common/network -->
-        <kafka.version>3.7.1</kafka.version>
+        <kafka.version>4.0.0</kafka.version>
         <bucket4j.version>8.10.1</bucket4j.version>
         <antlr.version>3.5.3</antlr.version>
         <snakeyaml.version>2.2</snakeyaml.version>


### PR DESCRIPTION
## Pull Request description

- Upgraded the Kafka client version from 3.7.1 to 4.0.0.
- Merged NetworkReceive from Kafka 4.0.0 with the TB shaded class (only code style and comment differences).
- Ensured successful compilation with no issues.
- Verified the changes by running docker-compose with locally built images: no errors observed.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



