### PR TITLE
feat: tenant temporary inactivation

### DIFF
--- a/application/src/main/data/upgrade/basic/schema_update.sql
+++ b/application/src/main/data/upgrade/basic/schema_update.sql
@@ -14,3 +14,5 @@
 -- limitations under the License.
 --
 
+ALTER TABLE tenant ADD COLUMN IF NOT EXISTS active boolean NOT NULL DEFAULT true;
+

--- a/application/src/main/java/org/thingsboard/server/config/TenantActiveFilter.java
+++ b/application/src/main/java/org/thingsboard/server/config/TenantActiveFilter.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.thingsboard.server.common.data.exception.TenantInactiveException;
+import org.thingsboard.server.dao.tenant.TenantService;
+import org.thingsboard.server.exception.ThingsboardErrorResponseHandler;
+import org.thingsboard.server.service.security.model.SecurityUser;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class TenantActiveFilter extends OncePerRequestFilter {
+
+    private final ThingsboardErrorResponseHandler errorResponseHandler;
+    private final TenantService tenantService;
+
+    @Override
+    public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+        SecurityUser user = getCurrentUser();
+        if (user != null && !user.isSystemAdmin()) {
+            if (!tenantService.isTenantActive(user.getTenantId())) {
+                errorResponseHandler.handle(new TenantInactiveException(), response);
+                return;
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilterAsyncDispatch() {
+        return false;
+    }
+
+    @Override
+    protected boolean shouldNotFilterErrorDispatch() {
+        return false;
+    }
+
+    protected SecurityUser getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof SecurityUser) {
+            return (SecurityUser) authentication.getPrincipal();
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/application/src/main/java/org/thingsboard/server/config/ThingsboardSecurityConfiguration.java
+++ b/application/src/main/java/org/thingsboard/server/config/ThingsboardSecurityConfiguration.java
@@ -141,6 +141,9 @@ public class ThingsboardSecurityConfiguration {
     private RateLimitProcessingFilter rateLimitProcessingFilter;
 
     @Autowired
+    private TenantActiveFilter tenantActiveFilter;
+
+    @Autowired
     private AuthExceptionHandler authExceptionHandler;
 
     @Bean
@@ -268,6 +271,7 @@ public class ThingsboardSecurityConfiguration {
                 .addFilterBefore(buildRefreshTokenProcessingFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(payloadSizeFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(rateLimitProcessingFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(tenantActiveFilter, RateLimitProcessingFilter.class)
                 .addFilterBefore(authExceptionHandler, buildRestLoginProcessingFilter().getClass());
         if (oauth2Configuration != null) {
             http.oauth2Login(login -> login

--- a/application/src/main/java/org/thingsboard/server/controller/TenantController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/TenantController.java
@@ -118,6 +118,32 @@ public class TenantController extends BaseController {
         return tbTenantService.save(tenant);
     }
 
+    @ApiOperation(value = "Activate Tenant (activateTenant)",
+            notes = "Activates the tenant, allowing its users to log in and use the API. " + SYSTEM_AUTHORITY_PARAGRAPH)
+    @PreAuthorize("hasAuthority('SYS_ADMIN')")
+    @PostMapping(value = "/tenant/{tenantId}/activate")
+    public Tenant activateTenant(
+            @Parameter(description = TENANT_ID_PARAM_DESCRIPTION)
+            @PathVariable(TENANT_ID) String strTenantId) throws Exception {
+        checkParameter(TENANT_ID, strTenantId);
+        TenantId tenantId = TenantId.fromUUID(toUUID(strTenantId));
+        Tenant tenant = checkTenantId(tenantId, Operation.WRITE);
+        return tbTenantService.activate(tenant);
+    }
+
+    @ApiOperation(value = "Deactivate Tenant (deactivateTenant)",
+            notes = "Deactivates the tenant, blocking its users from logging in or using the API. " + SYSTEM_AUTHORITY_PARAGRAPH)
+    @PreAuthorize("hasAuthority('SYS_ADMIN')")
+    @PostMapping(value = "/tenant/{tenantId}/deactivate")
+    public Tenant deactivateTenant(
+            @Parameter(description = TENANT_ID_PARAM_DESCRIPTION)
+            @PathVariable(TENANT_ID) String strTenantId) throws Exception {
+        checkParameter(TENANT_ID, strTenantId);
+        TenantId tenantId = TenantId.fromUUID(toUUID(strTenantId));
+        Tenant tenant = checkTenantId(tenantId, Operation.WRITE);
+        return tbTenantService.deactivate(tenant);
+    }
+
     @ApiOperation(value = "Delete Tenant (deleteTenant)",
             notes = "Deletes the tenant, it's customers, rule chains, devices and all other related entities. Referencing non-existing tenant Id will cause an error." + SYSTEM_OR_TENANT_AUTHORITY_PARAGRAPH)
     @PreAuthorize("hasAnyAuthority('SYS_ADMIN', 'TENANT_ADMIN')")

--- a/application/src/main/java/org/thingsboard/server/exception/ThingsboardErrorResponseHandler.java
+++ b/application/src/main/java/org/thingsboard/server/exception/ThingsboardErrorResponseHandler.java
@@ -48,6 +48,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 import org.springframework.web.util.WebUtils;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.EntityType;
+import org.thingsboard.server.common.data.exception.TenantInactiveException;
 import org.thingsboard.server.common.data.exception.ThingsboardErrorCode;
 import org.thingsboard.server.common.data.exception.ThingsboardException;
 import org.thingsboard.server.common.msg.tools.MaxPayloadSizeExceededException;
@@ -154,6 +155,8 @@ public class ThingsboardErrorResponseHandler extends ResponseEntityExceptionHand
                     } else {
                         handleThingsboardException(thingsboardException, response);
                     }
+                } else if (exception instanceof TenantInactiveException tenantInactiveException) {
+                    handleTenantInactiveException(response, tenantInactiveException);
                 } else if (exception instanceof TbRateLimitsException rateLimitsException) {
                     handleRateLimitException(response, rateLimitsException);
                 } else if (exception instanceof AccessDeniedException) {
@@ -192,6 +195,13 @@ public class ThingsboardErrorResponseHandler extends ResponseEntityExceptionHand
         HttpStatus status = errorCodeToStatus(errorCode);
         response.setStatus(status.value());
         JacksonUtil.writeValue(response.getWriter(), ThingsboardErrorResponse.of(thingsboardException.getMessage(), errorCode, status));
+    }
+
+    private void handleTenantInactiveException(HttpServletResponse response, TenantInactiveException exception) throws IOException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        JacksonUtil.writeValue(response.getWriter(),
+                ThingsboardErrorResponse.of(exception.getMessage(),
+                        ThingsboardErrorCode.AUTHENTICATION, HttpStatus.FORBIDDEN));
     }
 
     private void handleRateLimitException(HttpServletResponse response, TbRateLimitsException exception) throws IOException {
@@ -253,7 +263,9 @@ public class ThingsboardErrorResponseHandler extends ResponseEntityExceptionHand
         if (authenticationException instanceof BadCredentialsException || authenticationException instanceof UsernameNotFoundException) {
             JacksonUtil.writeValue(response.getWriter(), ThingsboardErrorResponse.of("Invalid username or password", ThingsboardErrorCode.AUTHENTICATION, HttpStatus.UNAUTHORIZED));
         } else if (authenticationException instanceof DisabledException) {
-            JacksonUtil.writeValue(response.getWriter(), ThingsboardErrorResponse.of("User account is not active", ThingsboardErrorCode.AUTHENTICATION, HttpStatus.UNAUTHORIZED));
+            String message = "Tenant is inactive".equals(authenticationException.getMessage())
+                    ? "Tenant is inactive" : "User account is not active";
+            JacksonUtil.writeValue(response.getWriter(), ThingsboardErrorResponse.of(message, ThingsboardErrorCode.AUTHENTICATION, HttpStatus.UNAUTHORIZED));
         } else if (authenticationException instanceof LockedException) {
             JacksonUtil.writeValue(response.getWriter(), ThingsboardErrorResponse.of("User account is locked due to security policy", ThingsboardErrorCode.AUTHENTICATION, HttpStatus.UNAUTHORIZED));
         } else if (authenticationException instanceof JwtExpiredTokenException) {

--- a/application/src/main/java/org/thingsboard/server/service/entitiy/tenant/DefaultTbTenantService.java
+++ b/application/src/main/java/org/thingsboard/server/service/entitiy/tenant/DefaultTbTenantService.java
@@ -65,6 +65,18 @@ public class DefaultTbTenantService extends AbstractTbEntityService implements T
     }
 
     @Override
+    public Tenant activate(Tenant tenant) throws Exception {
+        tenant.setActive(true);
+        return tenantService.saveTenant(tenant);
+    }
+
+    @Override
+    public Tenant deactivate(Tenant tenant) throws Exception {
+        tenant.setActive(false);
+        return tenantService.saveTenant(tenant);
+    }
+
+    @Override
     public void delete(Tenant tenant) throws Exception {
         TenantId tenantId = tenant.getId();
         tenantService.deleteTenant(tenantId);

--- a/application/src/main/java/org/thingsboard/server/service/security/auth/rest/RestAuthenticationProvider.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/auth/rest/RestAuthenticationProvider.java
@@ -18,6 +18,7 @@ package org.thingsboard.server.service.security.auth.rest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -35,6 +36,7 @@ import org.thingsboard.server.common.data.security.model.UserPasswordPolicy;
 import org.thingsboard.server.dao.customer.CustomerService;
 import org.thingsboard.server.exception.DataValidationException;
 import org.thingsboard.server.dao.settings.SecuritySettingsService;
+import org.thingsboard.server.dao.tenant.TenantService;
 import org.thingsboard.server.dao.user.UserService;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 import org.thingsboard.server.service.security.auth.AbstractAuthenticationProvider;
@@ -55,18 +57,21 @@ public class RestAuthenticationProvider extends AbstractAuthenticationProvider {
     private final SecuritySettingsService securitySettingsService;
     private final UserService userService;
     private final TwoFactorAuthService twoFactorAuthService;
+    private final TenantService tenantService;
 
     @Autowired
     public RestAuthenticationProvider(final UserService userService,
                                       final CustomerService customerService,
                                       final SystemSecurityService systemSecurityService,
                                       SecuritySettingsService securitySettingsService,
-                                      TwoFactorAuthService twoFactorAuthService) {
+                                      TwoFactorAuthService twoFactorAuthService,
+                                      TenantService tenantService) {
         super(customerService, null);
         this.userService = userService;
         this.systemSecurityService = systemSecurityService;
         this.securitySettingsService = securitySettingsService;
         this.twoFactorAuthService = twoFactorAuthService;
+        this.tenantService = tenantService;
     }
 
     @Override
@@ -130,6 +135,10 @@ public class RestAuthenticationProvider extends AbstractAuthenticationProvider {
 
             if (user.getAuthority() == null) {
                 throw new InsufficientAuthenticationException("User has no authority assigned");
+            }
+
+            if (!user.getTenantId().isSysTenantId() && !tenantService.isTenantActive(user.getTenantId())) {
+                throw new DisabledException("Tenant is inactive");
             }
 
             return new SecurityUser(user, userCredentials.isEnabled(), userPrincipal);

--- a/application/src/test/java/org/thingsboard/server/controller/TenantControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/TenantControllerTest.java
@@ -943,4 +943,98 @@ public class TenantControllerTest extends AbstractControllerTest {
         Mockito.reset(tbClusterService);
     }
 
+    @Test
+    public void testActivateDeactivateTenant() throws Exception {
+        loginSysAdmin();
+        // Create a separate tenant with its own admin user
+        Tenant tenant = new Tenant();
+        tenant.setTitle("Test inactive tenant");
+        Tenant savedTenant = saveTenant(tenant);
+        Assert.assertTrue("New tenant should be active by default", savedTenant.isActive());
+
+        User newTenantAdmin = new User();
+        newTenantAdmin.setAuthority(Authority.TENANT_ADMIN);
+        newTenantAdmin.setTenantId(savedTenant.getId());
+        newTenantAdmin.setEmail("inactive.tenant.admin@test.com");
+        createUser(newTenantAdmin, "password");
+
+        // Deactivate the tenant as SYS_ADMIN
+        loginSysAdmin();
+        Tenant deactivated = doPost("/api/tenant/" + savedTenant.getId().getId() + "/deactivate", null, Tenant.class);
+        Assert.assertFalse("Tenant should be inactive after deactivation", deactivated.isActive());
+
+        // SYS_ADMIN should still be able to read the tenant
+        Tenant found = doGet("/api/tenant/" + savedTenant.getId().getId(), Tenant.class);
+        Assert.assertNotNull(found);
+        Assert.assertFalse(found.isActive());
+
+        // The new tenant admin login should fail while tenant is inactive
+        doPost("/api/auth/login", new org.thingsboard.server.service.security.auth.rest.LoginRequest("inactive.tenant.admin@test.com", "password"))
+                .andExpect(status().isUnauthorized());
+
+        deleteTenant(savedTenant.getId());
+    }
+
+    @Test
+    public void testInactiveTenantApiBlocked() throws Exception {
+        loginSysAdmin();
+        Tenant tenant = new Tenant();
+        tenant.setTitle("Test blocked tenant");
+        Tenant savedTenant = saveTenant(tenant);
+
+        User newTenantAdmin = new User();
+        newTenantAdmin.setAuthority(Authority.TENANT_ADMIN);
+        newTenantAdmin.setTenantId(savedTenant.getId());
+        newTenantAdmin.setEmail("blocked.tenant.admin@test.com");
+        createUserAndLogin(newTenantAdmin, "password");
+
+        // Save token obtained before deactivation
+        String tenantAdminToken = this.token;
+
+        // Deactivate the tenant as SYS_ADMIN
+        loginSysAdmin();
+        doPost("/api/tenant/" + savedTenant.getId().getId() + "/deactivate", null, Tenant.class);
+
+        // Using the old token for a tenant admin API call should return 403
+        this.token = tenantAdminToken;
+        doGet("/api/tenant/" + savedTenant.getId().getId())
+                .andExpect(status().isForbidden());
+
+        deleteTenant(savedTenant.getId());
+    }
+
+    @Test
+    public void testActivateTenantRestoresAccess() throws Exception {
+        loginSysAdmin();
+        Tenant tenant = new Tenant();
+        tenant.setTitle("Test reactivated tenant");
+        Tenant savedTenant = saveTenant(tenant);
+
+        User newTenantAdmin = new User();
+        newTenantAdmin.setAuthority(Authority.TENANT_ADMIN);
+        newTenantAdmin.setTenantId(savedTenant.getId());
+        newTenantAdmin.setEmail("reactivated.tenant.admin@test.com");
+        createUser(newTenantAdmin, "password");
+
+        // Deactivate tenant
+        loginSysAdmin();
+        doPost("/api/tenant/" + savedTenant.getId().getId() + "/deactivate", null, Tenant.class);
+
+        // Verify login is blocked
+        doPost("/api/auth/login", new org.thingsboard.server.service.security.auth.rest.LoginRequest("reactivated.tenant.admin@test.com", "password"))
+                .andExpect(status().isUnauthorized());
+
+        // Reactivate tenant
+        Tenant activated = doPost("/api/tenant/" + savedTenant.getId().getId() + "/activate", null, Tenant.class);
+        Assert.assertTrue("Tenant should be active after activation", activated.isActive());
+
+        // Tenant admin should now be able to log in
+        login("reactivated.tenant.admin@test.com", "password");
+        Tenant found = doGet("/api/tenant/" + savedTenant.getId().getId(), Tenant.class);
+        Assert.assertNotNull(found);
+        Assert.assertTrue(found.isActive());
+
+        deleteTenant(savedTenant.getId());
+    }
+
 }

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/tenant/TenantService.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/tenant/TenantService.java
@@ -57,4 +57,6 @@ public interface TenantService extends EntityDaoService {
 
     List<Tenant> findTenantsByIds(TenantId callerId, List<TenantId> tenantIds);
 
+    boolean isTenantActive(TenantId tenantId);
+
 }

--- a/common/data/src/main/java/org/thingsboard/server/common/data/Tenant.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/Tenant.java
@@ -45,6 +45,9 @@ public class Tenant extends ContactBased<TenantId> implements HasTenantId, HasTi
     @Schema(description = "JSON object with Tenant Profile Id")
     private TenantProfileId tenantProfileId;
 
+    @Schema(description = "Indicates whether the tenant is active. Inactive tenants cannot log in or use the API.", example = "true")
+    private boolean active = true;
+
     @Getter @Setter
     private Long version;
 
@@ -61,7 +64,16 @@ public class Tenant extends ContactBased<TenantId> implements HasTenantId, HasTi
         this.title = tenant.getTitle();
         this.region = tenant.getRegion();
         this.tenantProfileId = tenant.getTenantProfileId();
+        this.active = tenant.isActive();
         this.version = tenant.getVersion();
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
     }
 
     public String getTitle() {
@@ -197,6 +209,8 @@ public class Tenant extends ContactBased<TenantId> implements HasTenantId, HasTi
         builder.append(phone);
         builder.append(", email=");
         builder.append(email);
+        builder.append(", active=");
+        builder.append(active);
         builder.append(", createdTime=");
         builder.append(createdTime);
         builder.append(", id=");

--- a/common/data/src/main/java/org/thingsboard/server/common/data/exception/TenantInactiveException.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/exception/TenantInactiveException.java
@@ -13,18 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.thingsboard.server.service.entitiy.tenant;
+package org.thingsboard.server.common.data.exception;
 
-import org.thingsboard.server.common.data.Tenant;
+public class TenantInactiveException extends RuntimeException {
 
-public interface TbTenantService {
-
-    Tenant save(Tenant tenant) throws Exception;
-
-    void delete(Tenant tenant) throws Exception;
-
-    Tenant activate(Tenant tenant) throws Exception;
-
-    Tenant deactivate(Tenant tenant) throws Exception;
+    public TenantInactiveException() {
+        super("Tenant is inactive");
+    }
 
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/model/ModelConstants.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/ModelConstants.java
@@ -123,6 +123,7 @@ public class ModelConstants {
     public static final String TENANT_REGION_PROPERTY = "region";
     public static final String TENANT_ADDITIONAL_INFO_PROPERTY = ADDITIONAL_INFO_PROPERTY;
     public static final String TENANT_TENANT_PROFILE_ID_PROPERTY = "tenant_profile_id";
+    public static final String TENANT_ACTIVE_PROPERTY = "active";
 
     /**
      * Tenant profile constants.

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractTenantEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractTenantEntity.java
@@ -72,6 +72,9 @@ public abstract class AbstractTenantEntity<T extends Tenant> extends BaseVersion
     @Column(name = ModelConstants.TENANT_TENANT_PROFILE_ID_PROPERTY, columnDefinition = "uuid")
     private UUID tenantProfileId;
 
+    @Column(name = ModelConstants.TENANT_ACTIVE_PROPERTY)
+    private boolean active;
+
     public AbstractTenantEntity() {
         super();
     }
@@ -92,6 +95,7 @@ public abstract class AbstractTenantEntity<T extends Tenant> extends BaseVersion
         if (tenant.getTenantProfileId() != null) {
             this.tenantProfileId = tenant.getTenantProfileId().getId();
         }
+        this.active = tenant.isActive();
     }
 
     public AbstractTenantEntity(TenantEntity tenantEntity) {
@@ -108,6 +112,7 @@ public abstract class AbstractTenantEntity<T extends Tenant> extends BaseVersion
         this.email = tenantEntity.getEmail();
         this.additionalInfo = tenantEntity.getAdditionalInfo();
         this.tenantProfileId = tenantEntity.getTenantProfileId();
+        this.active = tenantEntity.isActive();
     }
 
     protected Tenant toTenant() {
@@ -128,6 +133,7 @@ public abstract class AbstractTenantEntity<T extends Tenant> extends BaseVersion
         if (tenantProfileId != null) {
             tenant.setTenantProfileId(new TenantProfileId(tenantProfileId));
         }
+        tenant.setActive(this.active);
         return tenant;
     }
 

--- a/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
@@ -238,6 +238,12 @@ public class TenantServiceImpl extends AbstractCachedEntityService<TenantId, Ten
         return existsTenantCache.getAndPutInTransaction(tenantId, () -> tenantDao.existsById(tenantId, tenantId.getId()), false);
     }
 
+    @Override
+    public boolean isTenantActive(TenantId tenantId) {
+        Tenant tenant = findTenantById(tenantId);
+        return tenant != null && tenant.isActive();
+    }
+
     private final PaginatedRemover<TenantId, Tenant> tenantsRemover = new PaginatedRemover<>() {
 
         @Override

--- a/dao/src/main/resources/sql/schema-entities.sql
+++ b/dao/src/main/resources/sql/schema-entities.sql
@@ -475,6 +475,7 @@ CREATE TABLE IF NOT EXISTS tenant (
     title varchar(255),
     zip varchar(255),
     version BIGINT DEFAULT 1,
+    active boolean NOT NULL DEFAULT true,
     CONSTRAINT fk_tenant_profile FOREIGN KEY (tenant_profile_id) REFERENCES tenant_profile(id)
 );
 

--- a/dao/src/test/java/org/thingsboard/server/dao/service/TenantServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/TenantServiceTest.java
@@ -732,4 +732,44 @@ public class TenantServiceTest extends AbstractServiceTest {
         tenantProfile.setName("Test tenant profile");
         return tenantProfileService.saveTenantProfile(TenantId.SYS_TENANT_ID, tenantProfile);
     }
+
+    @Test
+    public void testIsTenantActiveDefault() {
+        Tenant tenant = new Tenant();
+        tenant.setTitle("Active tenant");
+        Tenant savedTenant = tenantService.saveTenant(tenant);
+        Assert.assertTrue("New tenant should be active by default", savedTenant.isActive());
+        Assert.assertTrue(tenantService.isTenantActive(savedTenant.getId()));
+        tenantService.deleteTenant(savedTenant.getId());
+    }
+
+    @Test
+    public void testDeactivateTenant() {
+        Tenant tenant = new Tenant();
+        tenant.setTitle("Tenant to deactivate");
+        Tenant savedTenant = tenantService.saveTenant(tenant);
+        Assert.assertTrue(tenantService.isTenantActive(savedTenant.getId()));
+
+        savedTenant.setActive(false);
+        tenantService.saveTenant(savedTenant);
+
+        Assert.assertFalse(tenantService.isTenantActive(savedTenant.getId()));
+        tenantService.deleteTenant(savedTenant.getId());
+    }
+
+    @Test
+    public void testReactivateTenant() {
+        Tenant tenant = new Tenant();
+        tenant.setTitle("Tenant to reactivate");
+        Tenant savedTenant = tenantService.saveTenant(tenant);
+
+        savedTenant.setActive(false);
+        savedTenant = tenantService.saveTenant(savedTenant);
+        Assert.assertFalse(tenantService.isTenantActive(savedTenant.getId()));
+
+        savedTenant.setActive(true);
+        tenantService.saveTenant(savedTenant);
+        Assert.assertTrue(tenantService.isTenantActive(savedTenant.getId()));
+        tenantService.deleteTenant(savedTenant.getId());
+    }
 }


### PR DESCRIPTION
## Summary

- Adds an `active` boolean flag to `Tenant` (default `true`) persisted via a new DB column with migration
- Enforces inactivation at three layers: REST API (HTTP 403 via `TenantActiveFilter`), login (HTTP 401 via `RestAuthenticationProvider`), and data model
- Adds SYS_ADMIN-only endpoints `POST /api/tenant/{tenantId}/activate` and `/deactivate`

## Changes

**Data model:** `Tenant.active` field, `ModelConstants`, `AbstractTenantEntity`, schema DDL + migration SQL

**Service:** `TenantService.isTenantActive()` + implementation in `TenantServiceImpl`

**Security:**
- `TenantInactiveException` — new exception class
- `TenantActiveFilter` — `OncePerRequestFilter` returning 403 for inactive-tenant sessions (skips SYS_ADMIN)
- `RestAuthenticationProvider` — throws `DisabledException` (401) at login time for inactive tenants
- `ThingsboardErrorResponseHandler` — handles `TenantInactiveException`

**REST API:** `TbTenantService.activate/deactivate`, implemented in `DefaultTbTenantService`, exposed in `TenantController`

## Test plan

- [ ] `TenantServiceTest` — `testIsTenantActiveDefault`, `testDeactivateTenant`, `testReactivateTenant`
- [ ] `TenantControllerTest` — `testActivateDeactivateTenant`, `testInactiveTenantApiBlocked`, `testActivateTenantRestoresAccess`

```bash
mvn -pl dao -Dtest=TenantServiceTest test -Dsurefire.failIfNoSpecifiedTests=false
mvn -pl application -Dtest=TenantControllerTest test -Dsurefire.failIfNoSpecifiedTests=false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)