### PR TITLE
Fix flaky Sparkplug connection test: handle 404 during device await

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/sparkplug/AbstractMqttV5ClientSparkplugTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/sparkplug/AbstractMqttV5ClientSparkplugTest.java
@@ -191,6 +191,7 @@ public abstract class AbstractMqttV5ClientSparkplugTest extends AbstractMqttInte
                 AtomicReference<Device> device = new AtomicReference<>();
                 await(alias + "find device [" + deviceName + "] after created")
                         .atMost(200, TimeUnit.SECONDS)
+                        .ignoreExceptions()
                         .until(() -> {
                             device.set(doGet("/api/tenant/devices?deviceName=" + deviceName, Device.class));
                             return device.get() != null;
@@ -236,6 +237,7 @@ public abstract class AbstractMqttV5ClientSparkplugTest extends AbstractMqttInte
             AtomicReference<Device> device = new AtomicReference<>();
             await(alias + "find device [" + deviceName + "] after created")
                     .atMost(200, TimeUnit.SECONDS)
+                    .ignoreExceptions()
                     .until(() -> {
                         device.set(doGet("/api/tenant/devices?deviceName=" + deviceName, Device.class));
                         return device.get() != null;


### PR DESCRIPTION
## Root cause

`doGet(url, Device.class)` in `AbstractWebTest` internally calls `.andExpect(status().isOk())`, so when the Sparkplug gateway device hasn't been provisioned yet the method throws `AssertionError` (404 not found) instead of returning `null`.

Awaitility propagates `Error` subclasses **immediately** — it does not treat them as "condition not yet met" and retry. As a result the test fails within ~3 s rather than retrying for the configured 200 s window, making it flaky whenever the device creation response is slightly delayed.

Confirmed by three identical failure runs:
```
java.lang.AssertionError: Status expected:<200> but was:<404>
  at AbstractMqttV5ClientSparkplugTest.java:192
```

## Changes

Two `await()` calls in `AbstractMqttV5ClientSparkplugTest` poll `doGet(url, Device.class)`:
- `connectClientWithCorrectAccessTokenWithNDEATHCreatedDevices`
- `connectClientWithCorrectAccessTokenWithNDEATHWithAliasCreatedDevices`

When the Sparkplug device hasn't been created yet, the REST call returns 404 → `AssertionError` → Awaitility re-throws immediately instead of continuing to poll.

> Note: the analogous `doGetAsyncTyped` calls in `AbstractMqttV5ClientSparkplugAttributesTest` and `AbstractMqttAttributesIntegrationTest` are PE-only additions and are fixed in the PE PR.

## Fix

Added `.ignoreExceptions()` to both `await()` calls so that a transient non-200 response is treated as "not yet" and polling continues for the full timeout, which is the intended behaviour.

## Test plan
- [ ] `MqttV5ClientSparkplugBConnectionTest#testConnectClientWithCorrectAccessTokenWithNDEATH_State_ONLINE_All_Then_OFFLINE_All` no longer fails on first poll
- [ ] All other Sparkplug connection tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)